### PR TITLE
Switch conda-ci to use proper setup-matlab GitHub Action instead of manual downloading files required for build

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         mamba-version: "*"
         channels: conda-forge,defaults
@@ -34,34 +34,9 @@ jobs:
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
         mamba install casadi=3.6.5
-
-    - name: Install files to enable compilation of mex files [Conda/Linux]
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
-        unzip msdk_R2020b_mexa64.zip
-        rm msdk_R2020b_mexa64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020b_mexa64" >> $GITHUB_ENV
-        echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
-
-    - name: Install files to enable compilation of mex files [Conda/macOS]
-      if: contains(matrix.os, 'macos')
-      run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexmaci64.zip
-        unzip msdk_R2020a_mexmaci64.zip
-        rm msdk_R2020a_mexmaci64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexmaci64" >> $GITHUB_ENV
-        echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
-
-    - name: Install files to enable compilation of mex files [Conda/Windows]
-      if: contains(matrix.os, 'windows')
-      shell: bash
-      run: |
-        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
-        unzip msdk_R2020a_mexw64.zip
-        rm msdk_R2020a_mexw64.zip
-        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexw64" >> $GITHUB_ENV
-        echo "GHA_Matlab_MEX_EXTENSION=mexw64" >> $GITHUB_ENV
+    
+    - name: Set up MATLAB
+      uses: matlab-actions/setup-matlab@v2
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
@@ -69,7 +44,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -GNinja -DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION} -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/build/install ..
+        cmake -GNinja -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/build/install ..
 
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')
@@ -77,7 +52,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 17 2022" -DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION} -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/build/install ..
+        cmake -G"Visual Studio 17 2022" -DBUILD_TESTING:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/build/install ..
 
     - name: Build
       shell: bash -l {0}


### PR DESCRIPTION
This is done as the CI was failing as now macos-latest is Apple Silicon.